### PR TITLE
Fix missing ICD10 categories

### DIFF
--- a/Resources/source_data/ICD10_categories.csv
+++ b/Resources/source_data/ICD10_categories.csv
@@ -10,3 +10,14 @@ H60-H95,Ear and mastoid process diseases
 I00-I99,Circulatory system diseases
 J00-J99,Respiratory system diseases
 K00-K95,Digestive system diseases
+L00-L99, Diseases of the skin and subcutaneous tissue
+M00-M99, Diseases of the musculoskeletal system and connective tissue
+N00-N99, Diseases of the genitourinary system
+O00-O9A,"Pregnancy, childbirth and the puerperium"
+P00-P96,Certain conditions originating in the perinatal period
+Q00-Q99,"Congenital malformations, deformations and chromosomal abnormalities"
+R00-R99,"Symptoms, signs and abnormal clinical and laboratory findings, not elsewhere classified"
+S00-T88,"Injury, poisoning and certain other consequences of external causes"
+U00-U85,"Codes for special purposes"
+V00-Y99,External causes of morbidity
+Z00-Z99,Factors influencing health status and contact with health services

--- a/who_mortality_cleaning_workbook.ipynb
+++ b/who_mortality_cleaning_workbook.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [
     {
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [
     {
@@ -458,7 +458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [
     {
@@ -595,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [
     {
@@ -902,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [
     {
@@ -938,7 +938,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -955,7 +955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [
     {
@@ -978,7 +978,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [
     {
@@ -1004,7 +1004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [
     {
@@ -1035,7 +1035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [
     {
@@ -1233,7 +1233,7 @@
        "[5 rows x 42 columns]"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1247,7 +1247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [
     {
@@ -1487,7 +1487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [
     {
@@ -1525,7 +1525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [
     {
@@ -1759,7 +1759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [
     {
@@ -1790,7 +1790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1809,7 +1809,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1819,7 +1819,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [
     {
@@ -2031,7 +2031,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [
     {
@@ -2153,7 +2153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [
     {
@@ -2181,7 +2181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2191,7 +2191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 122,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
This PR adds the following ICD10 categories that were missing with the initial implementation. 

> M00-M99, Diseases of the musculoskeletal system and connective tissue
> N00-N99, Diseases of the genitourinary system
> O00-O9A,"Pregnancy, childbirth and the puerperium"
> P00-P96,Certain conditions originating in the perinatal period
> Q00-Q99,"Congenital malformations, deformations and chromosomal abnormalities"
> R00-R99,"Symptoms, signs and abnormal clinical and laboratory findings, not elsewhere classified"
> S00-T88,"Injury, poisoning and certain other consequences of external causes"
> U00-U85,"Codes for special purposes"
> V00-Y99,External causes of morbidity
> Z00-Z99,Factors influencing health status and contact with health services

I've validated this reports COVID within the "Codes for special purposes" category. COVID is categorized under U071 and U072.

I wrote the following code to verify the categories apply now. 

```
# Filter the DataFrame to only show rows with the ICD code 'U071'
df_covid_filtered = df_mort[df_mort['ICD Code'].isin(['U071','U072'])]
df_covid_rel_filtered = df_mort[df_mort['ICD Code'] == 'U072']

# Display the filtered DataFrame
display(df_covid_filtered.head(2))
```
<img width="631" alt="Screenshot 2024-08-10 at 4 11 22 PM" src="https://github.com/user-attachments/assets/f0f20c91-e1a6-455f-8704-7ae862ac0de1">

